### PR TITLE
fix number format issues in locales other than US

### DIFF
--- a/src/com/dozingcatsoftware/vectorpinball/util/JsonPrettyPrinter.java
+++ b/src/com/dozingcatsoftware/vectorpinball/util/JsonPrettyPrinter.java
@@ -1,11 +1,12 @@
 package com.dozingcatsoftware.vectorpinball.util;
 
-import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -14,7 +15,7 @@ import java.util.Map;
  */
 public class JsonPrettyPrinter {
 
-    private static DecimalFormat floatFormat = new DecimalFormat("#.######");
+    private static NumberFormat floatFormat = NumberFormat.getInstance(Locale.US);
 
     public static String prettyPrint(Object obj, int indent) {
         StringBuilder buffer = new StringBuilder();


### PR DESCRIPTION
In my case (localated in germany Locale.DE) using `DecimalFormat("#.######")` (in JsonPrettyPrinter.java) lead to the use of comma as decimal delimiter destroying the JSON like so:
![image](https://github.com/dozingcat/Vector-Pinball-Editor/assets/7475191/c4cf8d40-2f7b-460e-8231-0cfec125ef91) original
-->
![image](https://github.com/dozingcat/Vector-Pinball-Editor/assets/7475191/92275542-c80e-4a41-9f52-9d1bff00be8d) with comma

Easy fix was to use `NumberFormat.getInstance(Locale.US)` according to [https://www.baeldung.com/java-8-localization](url) so I created a pull-request for it.

Not being "at home" in Java I cannot say if it might have side effects, so please take a closer look. ;-)
